### PR TITLE
Added ArgGroup

### DIFF
--- a/cli-customize-fruit-salad/src/main.rs
+++ b/cli-customize-fruit-salad/src/main.rs
@@ -16,6 +16,7 @@ use fruit_salad_maker::create_fruit_salad;
     author = "Your Name <your.email@example.com>",
     about = "Make a Fruit Salad"
 )]
+#[group(required = true, multiple = false)]
 struct Opts {
     /// Fruits input as a string of comma separated values
     #[clap(short, long)]


### PR DESCRIPTION
Added ArgGroup to make the example look aesthetic/elegant.
The current implementation doesn't put out any warning when one of the two methods of input aren't used.